### PR TITLE
Using 'env' in shebang for enhanced portability

### DIFF
--- a/tasks/iconizr/iconizr.phps
+++ b/tasks/iconizr/iconizr.phps
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 namespace Jkphl;


### PR DESCRIPTION
'#!/usr/bin/env php' is more portable than '#!/usr/bin/php' at the top of the script. Some people have unusual configurations for PHP (MAMP, for example). It's a minor, but useful change.
